### PR TITLE
Local zero/feature/delete account

### DIFF
--- a/src/main/java/com/example/LocalZero/controller/AuthController.java
+++ b/src/main/java/com/example/LocalZero/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.LocalZero.controller;
 
 import com.example.LocalZero.dto.AuthResponse;
+import com.example.LocalZero.dto.DeleteAccountRequest;
 import com.example.LocalZero.dto.LoginRequest;
 import com.example.LocalZero.dto.RegisterRequest;
 import com.example.LocalZero.service.IAuthService;
@@ -33,5 +34,13 @@ public class AuthController {
     @PostMapping("/logout")
     public void logout(@RequestHeader("Authorization") String authHeader) {
         authService.logout(authHeader.substring(7));
+    }
+
+    @DeleteMapping("/account")
+    public ResponseEntity<Void> deleteAccount(@Valid @RequestBody DeleteAccountRequest request,
+                                              @RequestHeader("Authorization") String authHeader) {
+
+        authService.deleteAccount(authHeader.substring(7), request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/LocalZero/dto/DeleteAccountRequest.java
+++ b/src/main/java/com/example/LocalZero/dto/DeleteAccountRequest.java
@@ -1,0 +1,12 @@
+package com.example.LocalZero.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeleteAccountRequest {
+
+    @NotBlank
+    private String password;
+
+}

--- a/src/main/java/com/example/LocalZero/dto/LoginRequest.java
+++ b/src/main/java/com/example/LocalZero/dto/LoginRequest.java
@@ -4,8 +4,10 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class LoginRequest {
 

--- a/src/main/java/com/example/LocalZero/dto/RegisterRequest.java
+++ b/src/main/java/com/example/LocalZero/dto/RegisterRequest.java
@@ -4,10 +4,12 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class RegisterRequest {
 
     @NotBlank

--- a/src/main/java/com/example/LocalZero/exception/DuplicateResourceException.java
+++ b/src/main/java/com/example/LocalZero/exception/DuplicateResourceException.java
@@ -1,0 +1,11 @@
+package com.example.LocalZero.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateResourceException extends RuntimeException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/LocalZero/service/IAuthService.java
+++ b/src/main/java/com/example/LocalZero/service/IAuthService.java
@@ -1,6 +1,7 @@
 package com.example.LocalZero.service;
 
 import com.example.LocalZero.dto.AuthResponse;
+import com.example.LocalZero.dto.DeleteAccountRequest;
 import com.example.LocalZero.dto.LoginRequest;
 import com.example.LocalZero.dto.RegisterRequest;
 
@@ -8,4 +9,5 @@ public interface IAuthService {
     AuthResponse register(RegisterRequest request);
     AuthResponse login(LoginRequest request);
     void logout(String token);
+    void deleteAccount(String token, DeleteAccountRequest request);
 }

--- a/src/main/java/com/example/LocalZero/service/deleteaccount/UserDeleteAccount.java
+++ b/src/main/java/com/example/LocalZero/service/deleteaccount/UserDeleteAccount.java
@@ -1,0 +1,58 @@
+package com.example.LocalZero.service.deleteaccount;
+
+
+import com.example.LocalZero.Model.BlacklistedToken;
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.exception.InvalidCredentialException;
+import com.example.LocalZero.repository.BlacklistedTokenRepository;
+import com.example.LocalZero.repository.UserRepository;
+import com.example.LocalZero.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service("userDeleteAccount")
+@RequiredArgsConstructor
+public class UserDeleteAccount extends UserDeleteAccountTemplate {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+    private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+
+    @Override
+    protected String extractEmail(String token) {
+        return jwtService.extractEmail(token);
+    }
+
+    @Override
+    protected User findUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidCredentialException("Invalid credentials"));
+    }
+
+    @Override
+    protected void verifyPassword(String rawPassword, String hashPassword) {
+        if (!passwordEncoder.matches(rawPassword, hashPassword)) {
+            throw new InvalidCredentialException("Invalid credential");
+        }
+    }
+
+    @Override
+    protected void blacklistToken(String token) {
+        Date expiresAt = jwtService.extractExpiration(token);
+        LocalDateTime expiresAtLDT = expiresAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+        blacklistedTokenRepository.save(new BlacklistedToken(token, LocalDateTime.now(), expiresAtLDT));
+    }
+
+    @Override
+    protected void deleteUser(User user) {
+        userRepository.delete(user);
+    }
+}

--- a/src/main/java/com/example/LocalZero/service/deleteaccount/UserDeleteAccountTemplate.java
+++ b/src/main/java/com/example/LocalZero/service/deleteaccount/UserDeleteAccountTemplate.java
@@ -1,0 +1,21 @@
+package com.example.LocalZero.service.deleteaccount;
+
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.dto.DeleteAccountRequest;
+
+public abstract class UserDeleteAccountTemplate {
+
+    public final void deleteAccount(String token, DeleteAccountRequest request) {
+        String email = extractEmail(token);
+        User user = findUser(email);
+        verifyPassword(request.getPassword(), user.getPassword());
+        blacklistToken(token);
+        deleteUser(user);
+    }
+
+    protected abstract String extractEmail(String token);
+    protected abstract User findUser(String email);
+    protected abstract void verifyPassword(String rawPassword, String hashPassword);
+    protected abstract void blacklistToken(String token);
+    protected abstract void deleteUser(User user);
+}

--- a/src/main/java/com/example/LocalZero/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/LocalZero/service/impl/AuthServiceImpl.java
@@ -1,9 +1,11 @@
 package com.example.LocalZero.service.impl;
 
 import com.example.LocalZero.dto.AuthResponse;
+import com.example.LocalZero.dto.DeleteAccountRequest;
 import com.example.LocalZero.dto.LoginRequest;
 import com.example.LocalZero.dto.RegisterRequest;
 import com.example.LocalZero.service.IAuthService;
+import com.example.LocalZero.service.deleteaccount.UserDeleteAccountTemplate;
 import com.example.LocalZero.service.login.UserLoginTemplate;
 import com.example.LocalZero.service.logout.UserLogoutTemplate;
 import com.example.LocalZero.service.registration.UserRegistrationTemplate;
@@ -16,15 +18,18 @@ public class AuthServiceImpl implements IAuthService {
     private final UserRegistrationTemplate registrationTemplate;
     private final UserLoginTemplate loginTemplate;
     private final UserLogoutTemplate logoutTemplate;
+    private final UserDeleteAccountTemplate userDeleteAccountTemplate;
 
     public AuthServiceImpl(
             @Qualifier("userRegistration") UserRegistrationTemplate registrationTemplate,
             @Qualifier("userLogin") UserLoginTemplate loginTemplate,
-            @Qualifier("userLogout") UserLogoutTemplate logoutTemplate) {
+            @Qualifier("userLogout") UserLogoutTemplate logoutTemplate,
+            @Qualifier("userDeleteAccount") UserDeleteAccountTemplate deleteAccountTemplate) {
 
         this.registrationTemplate = registrationTemplate;
         this.loginTemplate = loginTemplate;
         this.logoutTemplate = logoutTemplate;
+        this.userDeleteAccountTemplate = deleteAccountTemplate;
     }
 
     @Override
@@ -40,5 +45,10 @@ public class AuthServiceImpl implements IAuthService {
     @Override
     public void logout(String token) {
         logoutTemplate.logout(token);
+    }
+
+    @Override
+    public void deleteAccount(String token, DeleteAccountRequest request) {
+        userDeleteAccountTemplate.deleteAccount(token, request);
     }
 }

--- a/src/main/java/com/example/LocalZero/service/registration/UserRegistration.java
+++ b/src/main/java/com/example/LocalZero/service/registration/UserRegistration.java
@@ -3,7 +3,7 @@ package com.example.LocalZero.service.registration;
 import com.example.LocalZero.Model.Role;
 import com.example.LocalZero.Model.User;
 import com.example.LocalZero.dto.RegisterRequest;
-import com.example.LocalZero.exception.ValidationException;
+import com.example.LocalZero.exception.DuplicateResourceException;
 import com.example.LocalZero.repository.UserRepository;
 import com.example.LocalZero.service.JwtService;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class UserRegistration extends UserRegistrationTemplate {
     @Override
     protected void validateInput(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new ValidationException("Email already in use: " + request.getEmail());
+            throw new DuplicateResourceException("Email already in use: " + request.getEmail());
         }
     }
 
@@ -46,7 +46,7 @@ public class UserRegistration extends UserRegistrationTemplate {
         try {
             return userRepository.save(user);
         } catch (DataIntegrityViolationException e) {
-            throw new ValidationException("Email already in use: " + user.getEmail());
+            throw new DuplicateResourceException("Email already in use: " + user.getEmail());
         }
     }
 


### PR DESCRIPTION
 - added delete account flow 
 - it requires a jwt and correct password to delete the account
 - added a deleteaccount template
 - added the endpoint to delete account
 - small changes in register that now throws 409 instead 400 when duplicate email