### PR TITLE
Implement mockup service and activities

### DIFF
--- a/src/main/java/com/example/LocalZero/service/impl/SustainabilityServiceImpl.java
+++ b/src/main/java/com/example/LocalZero/service/impl/SustainabilityServiceImpl.java
@@ -43,11 +43,20 @@ public class SustainabilityServiceImpl implements ISustainabilityService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public List<EcoActionResponse> getEcoActionsHistory(String userEmail) {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with email: " + userEmail));
-        return ecoActionRepository.findByUserOrderByTimestampDesc(user).stream()
+        
+        List<com.example.LocalZero.Model.EcoAction> actions = ecoActionRepository.findByUserOrderByTimestampDesc(user);
+        if (actions.size() <= 9) {
+            com.example.LocalZero.service.sustainability.IEcoCommand generateMockCommand = 
+                new com.example.LocalZero.service.sustainability.GenerateMockEcoActionsCommand(user, ecoActionRepository);
+            generateMockCommand.execute();
+            actions = ecoActionRepository.findByUserOrderByTimestampDesc(user);
+        }
+        
+        return actions.stream()
                 .map(action -> new EcoActionResponse(action.getDescription(), action.getTimestamp()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/LocalZero/service/sustainability/GenerateMockEcoActionsCommand.java
+++ b/src/main/java/com/example/LocalZero/service/sustainability/GenerateMockEcoActionsCommand.java
@@ -1,0 +1,39 @@
+package com.example.LocalZero.service.sustainability;
+
+import com.example.LocalZero.Model.EcoAction;
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.repository.EcoActionRepository;
+
+import java.util.List;
+
+public class GenerateMockEcoActionsCommand implements IEcoCommand {
+
+    private final User user;
+    private final EcoActionRepository repository;
+
+    private static final List<String> MOCK_ACTIVITIES = List.of(
+            "Cycled to work instead of driving",
+            "Recycled plastic and glass bottles",
+            "Participated in a community park clean-up",
+            "Composted organic food waste",
+            "Switched to energy-efficient LED bulbs",
+            "Used public transport for daily commute",
+            "Planted a tree in the neighborhood",
+            "Reduced shower time to save water",
+            "Bought locally produced vegetables",
+            "Organized a zero-waste community workshop"
+    );
+
+    public GenerateMockEcoActionsCommand(User user, EcoActionRepository repository) {
+        this.user = user;
+        this.repository = repository;
+    }
+
+    @Override
+    public void execute() {
+        for (String activity : MOCK_ACTIVITIES) {
+            EcoAction action = new EcoAction(activity, user);
+            repository.save(action);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces logic to ensure that users always have at least 10 eco actions in their history by generating mock actions if necessary. It also adds a new command class to encapsulate the mock action generation logic.

**Eco action history improvements:**

* The `getEcoActionsHistory` method in `SustainabilityServiceImpl` now checks if a user has fewer than 10 eco actions and, if so, generates mock eco actions to populate their history. This ensures a more meaningful user experience, especially for new users.

**New command for mock data generation:**

* Added the `GenerateMockEcoActionsCommand` class, which implements the `IEcoCommand` interface and is responsible for creating and saving a predefined set of mock eco actions for a given user.