### PR TITLE
Implement role assignment logic and endpoint in UserService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "LocalZero_VT26",
       "workspaces": [
         "frontend"
       ]
@@ -62,6 +63,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -269,40 +271,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -880,6 +848,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -926,6 +895,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -941,6 +911,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -967,13 +949,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1033,6 +1016,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1139,7 +1123,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1274,6 +1257,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1745,6 +1729,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2210,7 +2207,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2329,6 +2325,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2399,6 +2396,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2408,6 +2406,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2416,9 +2415,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2438,12 +2437,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2627,6 +2626,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2751,6 +2751,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/main/java/com/example/LocalZero/controller/UserController.java
+++ b/src/main/java/com/example/LocalZero/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.LocalZero.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.example.LocalZero.dto.AssignRoleRequest;
 
 import java.util.List;
 
@@ -18,5 +19,12 @@ public class UserController {
     @GetMapping("/available")
     public ResponseEntity<List<UserSummaryResponse>> getAvailableUsers(@RequestAttribute("email") String email) {
         return ResponseEntity.ok(userService.getAvailableUsers(email));
+    }
+
+    @PutMapping("/assign-role")
+    public ResponseEntity<Void> assignrole(@jakarta.validation.Valid @RequestBody AssignRoleRequest request,
+                                           @RequestAttribute("email") String callerEmail){
+        userService.assignRole(request, callerEmail);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/LocalZero/service/IUserService.java
+++ b/src/main/java/com/example/LocalZero/service/IUserService.java
@@ -1,8 +1,10 @@
 package com.example.LocalZero.service;
 
+import com.example.LocalZero.dto.AssignRoleRequest;
 import com.example.LocalZero.dto.UserSummaryResponse;
 import java.util.List;
 
 public interface IUserService {
     List<UserSummaryResponse> getAvailableUsers(String userEmail);
+    void assignRole(AssignRoleRequest request, String callerEmail);
 }

--- a/src/main/java/com/example/LocalZero/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/LocalZero/service/impl/UserServiceImpl.java
@@ -100,6 +100,6 @@ public class UserServiceImpl implements IUserService {
                 targetRoles.add(Role.ADMIN);
             }
         }
-        userRepository.save(caller);
+        userRepository.save(target);
     }
 }

--- a/src/main/java/com/example/LocalZero/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/LocalZero/service/impl/UserServiceImpl.java
@@ -65,4 +65,41 @@ public class UserServiceImpl implements IUserService {
         return result;
     }
 
+    @Override
+    @org.springframework.transaction.annotation.Transactional
+    public void assignRole(com.example.LocalZero.dto.AssignRoleRequest request, String callerEmail) {
+        User caller = userRepository.findByEmail(callerEmail)
+                .orElseThrow(() -> new ResourceNotFoundException("Caller not found"));
+
+        User target = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException("Target user not found"));
+
+        //CoR
+        com.example.LocalZero.service.validation.RoleAssignmentValidator
+                callerCheck = new com.example.LocalZero.service.validation.CallerPermissionValidator();
+        com.example.LocalZero.service.validation.RoleAssignmentValidator
+                locationCheck = new com.example.LocalZero.service.validation.LocationMatchValidator();
+        com.example.LocalZero.service.validation.RoleAssignmentValidator
+                transitionCheck = new com.example.LocalZero.service.validation.RoleTransitionValidator();
+
+        callerCheck.setNext(locationCheck);
+        locationCheck.setNext(transitionCheck);
+
+        callerCheck.validate(caller, target, request);
+
+        List<Role> targetRoles = target.getRoles();
+        if (request.getRole() == Role.ORGANIZER) {
+            if (!targetRoles.contains(Role.ORGANIZER)) {
+                targetRoles.add(Role.ORGANIZER);
+            }
+        } else if (request.getRole() == Role.RESIDENT) {
+            targetRoles.clear();
+            targetRoles.add(Role.RESIDENT);
+        } else if (request.getRole() == Role.ADMIN) {
+            if (!targetRoles.contains(Role.ADMIN)) {
+                targetRoles.add(Role.ADMIN);
+            }
+        }
+        userRepository.save(caller);
+    }
 }

--- a/src/main/java/com/example/LocalZero/service/validation/CallerPermissionValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/CallerPermissionValidator.java
@@ -1,0 +1,19 @@
+package com.example.LocalZero.service.validation;
+
+import com.example.LocalZero.Model.Role;
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.dto.AssignRoleRequest;
+import com.example.LocalZero.exception.ValidationException;
+
+public class CallerPermissionValidator extends RoleAssignmentValidator{
+
+    @Override
+    protected void doValidate(User caller, User target, AssignRoleRequest request) {
+        boolean isOrganizer = caller.getRoles().contains(Role.ORGANIZER);
+        boolean isAdmin = caller.getRoles().contains(Role.ADMIN);
+
+        if (!isOrganizer && !isAdmin) {
+            throw new ValidationException("Only admins and organizers can change roles!");
+        }
+    }
+}

--- a/src/main/java/com/example/LocalZero/service/validation/LocationMatchValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/LocationMatchValidator.java
@@ -1,0 +1,25 @@
+package com.example.LocalZero.service.validation;
+
+import com.example.LocalZero.Model.Role;
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.dto.AssignRoleRequest;
+import com.example.LocalZero.exception.ValidationException;
+
+public class LocationMatchValidator extends RoleAssignmentValidator {
+
+    @Override
+    protected void doValidate(User caller, User target, AssignRoleRequest request) {
+        boolean isOrganizer = caller.getRoles().contains(Role.ORGANIZER);
+        boolean isAdmin = caller.getRoles().contains(Role.ADMIN);
+
+        if (isOrganizer && !isAdmin) {
+            String callerLocation = caller.getLocation();
+            String targetLocation = target.getLocation();
+
+            if (callerLocation == null || targetLocation == null || !callerLocation.equals(targetLocation)) {
+                throw new ValidationException("Organizers can only change roles for users in the same location!");
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/example/LocalZero/service/validation/RoleAssignmentValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/RoleAssignmentValidator.java
@@ -1,0 +1,24 @@
+package com.example.LocalZero.service.validation;
+
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.dto.AssignRoleRequest;
+
+public class RoleAssignmentValidator {
+
+    protected RoleAssignmentValidator next;
+
+    public void setNext(RoleAssignmentValidator next) {
+        this.next = next;
+    }
+
+
+    public void validate(User caller, User target, AssignRoleRequest request){
+        doValidate(caller, target, request);
+        if(next != null){
+            next.validate(caller, target, request);
+        }
+    }
+
+    protected abstract void doValidate(User caller, User target, AssignRoleRequest request);
+
+}

--- a/src/main/java/com/example/LocalZero/service/validation/RoleAssignmentValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/RoleAssignmentValidator.java
@@ -3,7 +3,7 @@ package com.example.LocalZero.service.validation;
 import com.example.LocalZero.Model.User;
 import com.example.LocalZero.dto.AssignRoleRequest;
 
-public class RoleAssignmentValidator {
+public abstract class RoleAssignmentValidator {
 
     protected RoleAssignmentValidator next;
 

--- a/src/main/java/com/example/LocalZero/service/validation/RoleTransitionValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/RoleTransitionValidator.java
@@ -1,0 +1,24 @@
+package com.example.LocalZero.service.validation;
+
+import com.example.LocalZero.Model.Role;
+import com.example.LocalZero.Model.User;
+import com.example.LocalZero.dto.AssignRoleRequest;
+import com.example.LocalZero.exception.ValidationException;
+
+public class RoleTransitionValidator extends RoleAssignmentValidator {
+
+    @Override
+    protected void doValidate(User caller, User target, AssignRoleRequest request) {
+        boolean isAdmin = caller.getRoles().contains(Role.ADMIN);
+        Role requestedRole = request.getRole();
+
+        if (requestedRole == Role.ADMIN && !isAdmin) {
+            throw new ValidationException("Only admins can assign the admin role.");
+        }
+
+        boolean targetIsOrganizer = target.getRoles().contains(Role.ORGANIZER);
+        if (targetIsOrganizer && requestedRole == Role.RESIDENT && !isAdmin) {
+            throw new ValidationException("Only organizers can assign the admin role.");
+        }
+    }
+}

--- a/src/main/java/com/example/LocalZero/service/validation/RoleTransitionValidator.java
+++ b/src/main/java/com/example/LocalZero/service/validation/RoleTransitionValidator.java
@@ -13,12 +13,12 @@ public class RoleTransitionValidator extends RoleAssignmentValidator {
         Role requestedRole = request.getRole();
 
         if (requestedRole == Role.ADMIN && !isAdmin) {
-            throw new ValidationException("Only admins can assign the admin role.");
+            throw new ValidationException("Only admins can assign the admin role!");
         }
 
         boolean targetIsOrganizer = target.getRoles().contains(Role.ORGANIZER);
         if (targetIsOrganizer && requestedRole == Role.RESIDENT && !isAdmin) {
-            throw new ValidationException("Only organizers can assign the admin role.");
+            throw new ValidationException("Only admins can demote organizers to residents!");
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new role assignment feature to the user management system. It adds an endpoint to assign roles to users, implements a validation chain using the Chain of Responsibility pattern to enforce permission and business rules, and updates the service layer accordingly.

**Role Assignment Feature:**

* Added a new `PUT /assign-role` endpoint in `UserController` to allow admins and organizers to assign roles to users.
* Updated `IUserService` and implemented `assignRole` in `UserServiceImpl` to handle the role assignment logic, including role-specific behaviors (e.g., only admins can assign admin roles, organizers can only assign roles within their location, etc.). 

**Validation Chain Implementation:**

* Introduced the `RoleAssignmentValidator` abstract class and concrete implementations: `CallerPermissionValidator`, `LocationMatchValidator`, and `RoleTransitionValidator`. These validators enforce that only authorized users can assign roles, organizers are limited to their location, and only admins can assign or demote certain roles. 

**DTO Import:**

* Imported the `AssignRoleRequest` DTO where necessary to support the new endpoint and service method.