### PR TITLE
Add /api prefix to UserController and MessagingController endpoints

### DIFF
--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -2,7 +2,7 @@ import api from './api'
 
 const userService = {
     getAvailableUser: async () => {
-        const response = await api.get('/users/available')
+        const response = await api.get('/api/users/available')
         return response.data
     }
 }

--- a/src/main/java/com/example/LocalZero/controller/MessagingController.java
+++ b/src/main/java/com/example/LocalZero/controller/MessagingController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/messaging")
+@RequestMapping("/api/messaging")
 @RequiredArgsConstructor
 public class MessagingController {
 

--- a/src/main/java/com/example/LocalZero/controller/UserController.java
+++ b/src/main/java/com/example/LocalZero/controller/UserController.java
@@ -10,7 +10,7 @@ import com.example.LocalZero.dto.AssignRoleRequest;
 import java.util.List;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/users/")
 @RequiredArgsConstructor
 public class UserController {
 


### PR DESCRIPTION
This pull request updates the API endpoint paths in both the frontend and backend to ensure consistency and proper namespacing under `/api`. The changes affect user and messaging-related endpoints in both Java controllers and the JavaScript service.

**API endpoint path updates:**

* [`src/main/java/com/example/LocalZero/controller/UserController.java`](diffhunk://#diff-8dfc9703c2eeefca348d795d3c97d11e3ead93bcff4e0a43ff079c78a70e8de8L13-R13): Changed the base request mapping from `/users` to `/api/users/` to namespace user-related endpoints under `/api`.
* [`src/main/java/com/example/LocalZero/controller/MessagingController.java`](diffhunk://#diff-8588b142cf8400231efa7a697941b92ce631766aa67d2119a2f350d9d99663bbL16-R16): Changed the base request mapping from `/messaging` to `/api/messaging` to namespace messaging-related endpoints under `/api`.
* [`frontend/src/services/userService.js`](diffhunk://#diff-eeccb9fed9845230d047380950630bec7628742d79bbd6218b1fb16fdd0900a6L5-R5): Updated the frontend service to call `/api/users/available` instead of `/users/available`, matching the backend path change.