### PR TITLE
Enforce user roles for initiative creation and button rendering

### DIFF
--- a/frontend/src/pages/InitiativePage.jsx
+++ b/frontend/src/pages/InitiativePage.jsx
@@ -118,12 +118,16 @@ function InitiativePage() {
                         <p style={{ color: '#6b7280', margin: '6px 0 0 0', fontSize: '15px' }}>Find crowdsourced community work happening near you.</p>
                     </div>
 
-                    <button
-                        onClick={() => setShowCreateModal(true)}
-                        style={{ padding: '12px 22px', backgroundColor: '#2563eb', color: '#ffffff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600', fontSize: '15px' }}
-                    >
-                        Launch Initiative
-                    </button>
+                    {(user?.roles?.includes('ORGANIZER') || user?.roles?.includes('ADMIN')) && (
+                        <button
+                            onClick={() => setShowCreateModal(true)}
+                            style={{ padding: '12px 22px', backgroundColor: '#2563eb', color:
+                                    '#ffffff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600', fontSize: '15px'
+                            }}
+                        >
+                            Launch Initiative
+                        </button>
+                    )}
                 </div>
 
                 {error && (

--- a/src/main/java/com/example/LocalZero/service/impl/InitiativeServiceImpl.java
+++ b/src/main/java/com/example/LocalZero/service/impl/InitiativeServiceImpl.java
@@ -97,6 +97,10 @@ public class InitiativeServiceImpl implements IInitiativeService {
         User creator = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with email: " + userEmail));
 
+        if (!creator.getRoles().contains(Role.ORGANIZER) && !creator.getRoles().contains(Role.ADMIN)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only users with ORGANIZER or ADMIN role can create initiatives.");
+        }
+
         Initiative initiative = new Initiative(
                 request.getTitle(),
                 request.getDescription(),


### PR DESCRIPTION
This pull request introduces role-based access control for creating initiatives, ensuring that only users with the `ORGANIZER` or `ADMIN` roles can launch new initiatives. The main changes are as follows:

**Backend authorization logic:**

* Added a check in `InitiativeServiceImpl.java` to throw a `FORBIDDEN` error if a user without the `ORGANIZER` or `ADMIN` role attempts to create an initiative.

**Frontend UI restriction:**

* Updated `InitiativePage.jsx` so that the "Launch Initiative" button is only visible to users with the `ORGANIZER` or `ADMIN` roles.